### PR TITLE
Fix documentation placeholders and add contributing guide

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-[Repository Name].cadtasticsolutions.com
+subscription-framework.cadtasticsolutions.com

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing to Subscription Framework
+
+Thank you for taking the time to contribute! Please follow these steps:
+
+1. Fork this repository and create your branch from `main`.
+2. Make your changes and ensure the project continues to build.
+3. Commit your work with clear messages.
+4. Open a pull request describing the changes.
+
+Please keep contributions focused and respectful.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: [Repository Name]
+title: Subscription Framework
 description: 
 theme: jekyll-theme-minimal
 remote_theme: pages-themes/minimal@v0.2.0
@@ -10,20 +10,20 @@ markdown: GFM
 highlighter: rouge
 
 # Set custom domain URL
-url: "https://[Repository Name].cadtasticsolutions.com"
+url: "https://subscription-framework.cadtasticsolutions.com"
 
 # Leave baseurl empty since you're using a root domain
 baseurl: ""
 
 # Repository metadata for GitHub Pages
-repository: [Organization Name]/[Repository Name]
+repository: Cadtastic-Solutions/Subscription-Framework
 
 # Pagination settings
 paginate: 5
 paginate_path: "/page:num"
 
 # Author information
-author: "[Project Maintainer Name]"
+author: "Addam Boord"
 
 # Exclude unnecessary files from the build
 exclude:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# Welcome to [Repository Name]
+# Welcome to Subscription Framework
 
-Welcome to the **[Repository Name]** project! This repository is part of [Organization Name] and is designed to [brief purpose of the repository]. Here you will find all the documentation, code, and resources needed to get started.
+Welcome to the **Subscription Framework** project! This repository is part of Cadtastic Solutions and is designed to [brief purpose of the repository]. Here you will find all the documentation, code, and resources needed to get started.
 
 ---
 
@@ -32,15 +32,15 @@ Follow these steps to set up and run the project locally:
 ### Installation
 1. Clone the repository:
    ```bash
-   git clone https://github.com/[username]/[repository-name].git
+   git clone https://github.com/Cadtastic-Solutions/Subscription-Framework.git
    ```
 2. Navigate to the project directory:
    ```bash
-   cd [repository-name]
+   cd Subscription-Framework
    ```
 3. Install dependencies:
    ```bash
-   [Dependency installation command]
+   dotnet restore
    ```
 
 ---
@@ -51,7 +51,7 @@ Follow these steps to set up and run the project locally:
 
 ### Example Usage
 ```bash
-[Example command or script]
+dotnet run
 ```
 
 ---
@@ -80,16 +80,16 @@ For more details, see our [Contributing Guidelines](CONTRIBUTING.md).
 
 ## License
 
-This project is licensed under the **[License Name]**. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the **Apache License 2.0**. See the [LICENSE](LICENSE) file for details.
 
 ---
 
 ## Contact
 
 For questions or support, please reach out to:
-- **[Project Maintainer Name]**
-- Email: [email@example.com]
+- **Addam Boord**
+- Email: addam.boord@cadtasticsolutions.com
 - [Other contact info or links, e.g., issue tracker, discussion forums]
 
 ---
-[Repository Name] is maintained by [Organization Name].
+Subscription Framework is maintained by Cadtastic Solutions.


### PR DESCRIPTION
## Summary
- clean up documentation placeholders with real project info
- add missing `docs/CONTRIBUTING.md` referenced by the docs
- update the GitHub Pages config and CNAME

## Testing
- `true`