### PR TITLE
Add planning documentation and fill placeholders

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,13 @@
 # Welcome to Subscription Framework
 
-Welcome to the **Subscription Framework** project! This repository is part of Cadtastic Solutions and is designed to [brief purpose of the repository]. Here you will find all the documentation, code, and resources needed to get started.
+Welcome to the **Subscription Framework** project! This repository is part of Cadtastic Solutions and provides a reference implementation for a subscription‑based licensing system. Here you will find the source code, architecture documentation, and planning resources to help you deploy and extend the framework.
 
 ---
 
 ## Table of Contents
 
 - [About the Project](#about-the-project)
+- [Project Planning](#project-planning)
 - [Getting Started](#getting-started)
 - [Usage](#usage)
 - [Contributing](#contributing)
@@ -17,7 +18,13 @@ Welcome to the **Subscription Framework** project! This repository is part of Ca
 
 ## About the Project
 
-[Provide a high-level overview of the project, its goals, and its use case. Include any relevant background information.]
+Subscription Framework provides a fully featured licensing service built on Azure. It integrates **Stripe** for billing, **Azure API Management** for key management, and a custom **License Service** to enforce online and offline validations. The goal is to give software vendors a secure, repeatable foundation for managing trials, paid plans, and feature entitlements across desktop and cloud applications.
+
+---
+
+## Project Planning
+
+Detailed planning information, including the overall scope, development phases, and a proposed timeline, is available in [Project Planning](planning.md).
 
 ---
 
@@ -26,8 +33,10 @@ Welcome to the **Subscription Framework** project! This repository is part of Ca
 Follow these steps to set up and run the project locally:
 
 ### Prerequisites
-- [List required software, tools, or libraries]
-- Installation instructions for required dependencies.
+- [Git](https://git-scm.com/) for version control
+- [.NET 6 SDK](https://dotnet.microsoft.com/download) installed
+- An Azure account with permissions to create resources
+- A Stripe account for testing billing flows
 
 ### Installation
 1. Clone the repository:
@@ -47,12 +56,13 @@ Follow these steps to set up and run the project locally:
 
 ## Usage
 
-[Provide instructions and examples for using the project.]
+After restoring dependencies you can run the sample License Service locally:
 
-### Example Usage
 ```bash
 dotnet run
 ```
+
+The service exposes basic endpoints for license validation which can be called through Azure API Management once deployed.
 
 ---
 
@@ -87,9 +97,8 @@ This project is licensed under the **Apache License 2.0**. See the [LICENSE](LIC
 ## Contact
 
 For questions or support, please reach out to:
-- **Addam Boord**
-- Email: addam.boord@cadtasticsolutions.com
-- [Other contact info or links, e.g., issue tracker, discussion forums]
+- **Addam Boord** – [addam.boord@cadtasticsolutions.com](mailto:addam.boord@cadtasticsolutions.com)
+- You can also open issues on the project repository if you encounter problems or have feature requests.
 
 ---
 Subscription Framework is maintained by Cadtastic Solutions.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -1,0 +1,53 @@
+# Project Planning
+
+This document outlines the expected scope of work, rough order of magnitude (ROM), and a proposed development timeline for the Subscription Framework.
+
+## Project Scope
+
+The framework delivers a licensing platform for a single software vendor. It uses **Stripe** for subscription billing, **Azure API Management** for API gateway and key management, and a custom **License Service** for handling subscription state, license validation, and offline tokens. An internal admin dashboard allows administrators to manage plans and licenses.
+
+## Rough Order of Magnitude
+
+A senior engineer working approximately **20 hours per week** can deliver a minimal production system in about **4–6 months**. The effort breaks down roughly as follows:
+
+1. **Environment & Core Service (3–4 weeks)** – provision Azure resources and scaffold the License Service.
+2. **Stripe & Subscription Handling (3–4 weeks)** – integrate Stripe webhooks and automate license creation.
+3. **License Validation & Security (3–4 weeks)** – implement online/offline validation and secure key handling.
+4. **Admin Dashboard (3–4 weeks)** – build the internal portal for managing users and plans.
+5. **Refinements & Testing (3–4 weeks)** – add monitoring, analytics, and prepare for deployment.
+
+## Development Iterations
+
+1. **Setup & Baseline**
+   - Provision Azure resources.
+   - Scaffold the License Service and initial APIM configuration.
+2. **Stripe Integration**
+   - Configure Stripe products and webhook handling.
+   - Automate APIM subscription creation after payment.
+3. **License Service Logic**
+   - Persist license records and enforce App GUID checks.
+   - Provide offline token generation.
+4. **Admin Dashboard**
+   - Secure portal for managing plans and license states.
+5. **Offline & Grace Period Handling**
+   - Finalize offline validation and handle paused/canceled subscriptions.
+6. **Monitoring & Analytics**
+   - Instrument services and document deployment.
+
+## Proposed Timeline
+
+```mermaid
+gantt
+    title Project Timeline (starting 5/19/2025)
+    dateFormat  YYYY-MM-DD
+    section Iterations
+    Setup & Baseline             :active,  setup,   2025-05-19, 21d
+    Stripe Integration           :        stripe,  2025-06-09, 21d
+    License Service Logic        :        logic,   2025-06-30, 21d
+    Admin Dashboard              :        admin,   2025-07-21, 21d
+    Offline & Grace Period       :        offline, 2025-08-11, 21d
+    Monitoring & Analytics       :        monitor, 2025-09-01, 21d
+    Finalization & Buffer        :        buffer,  2025-09-22, 21d
+```
+
+The exact dates may shift as the project progresses, but this provides an estimated sequence of work assuming a 20-hour work week.


### PR DESCRIPTION
## Summary
- describe the Subscription Framework purpose
- link to new Project Planning page
- detail prerequisites and usage in docs
- add contact info
- provide a planning document with ROM, iterations and a timeline

## Testing
- `git status --short`