### PR TITLE
Create scaffolding for independent src projects

### DIFF
--- a/SubscriptionFramework.sln
+++ b/SubscriptionFramework.sln
@@ -1,0 +1,5 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.0
+MinimumVisualStudioVersion = 10.0.40219.1
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This folder contains project-wide documentation.

--- a/src/AdminDashboard/README.md
+++ b/src/AdminDashboard/README.md
@@ -1,0 +1,3 @@
+# AdminDashboard
+
+Internal admin web portal used to manage users, subscriptions and product plans. This project is expected to be implemented using ASP.NET (Blazor or MVC).

--- a/src/AdminDashboard/docs/README.md
+++ b/src/AdminDashboard/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Project specific documentation will go here.

--- a/src/AdminDashboard/tests/README.md
+++ b/src/AdminDashboard/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Automated tests for this project.

--- a/src/ClientSdk/README.md
+++ b/src/ClientSdk/README.md
@@ -1,0 +1,3 @@
+# ClientSdk
+
+Optional client library to help applications integrate with the License Service.

--- a/src/ClientSdk/docs/README.md
+++ b/src/ClientSdk/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Project specific documentation will go here.

--- a/src/ClientSdk/tests/README.md
+++ b/src/ClientSdk/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Automated tests for this project.

--- a/src/Infrastructure/README.md
+++ b/src/Infrastructure/README.md
@@ -1,0 +1,3 @@
+# Infrastructure
+
+Deployment scripts and infrastructure as code for provisioning cloud resources (e.g., Bicep or Terraform).

--- a/src/Infrastructure/docs/README.md
+++ b/src/Infrastructure/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Project specific documentation will go here.

--- a/src/Infrastructure/tests/README.md
+++ b/src/Infrastructure/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Automated tests for this project.

--- a/src/LicenseService/README.md
+++ b/src/LicenseService/README.md
@@ -1,0 +1,3 @@
+# LicenseService
+
+ASP.NET backend that handles license generation, validation, and Stripe webhook processing. This project implements core business logic for issuing and validating licenses.

--- a/src/LicenseService/docs/README.md
+++ b/src/LicenseService/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Project specific documentation will go here.

--- a/src/LicenseService/tests/README.md
+++ b/src/LicenseService/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Automated tests for this project.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,3 @@
+# src
+
+Contains the implementation projects for the Subscription Framework.

--- a/src/Shared/README.md
+++ b/src/Shared/README.md
@@ -1,0 +1,3 @@
+# Shared
+
+Class library containing common models and utilities shared across other projects.

--- a/src/Shared/docs/README.md
+++ b/src/Shared/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Project specific documentation will go here.

--- a/src/Shared/tests/README.md
+++ b/src/Shared/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Automated tests for this project.


### PR DESCRIPTION
## Summary
- add minimal `SubscriptionFramework.sln`
- scaffold `src/` directory and subprojects
- add placeholder `docs/` and `tests/` folders for each project
- include new READMEs with a short overview

## Testing
- `git status --short`
- `git log -1 --stat`
