### PR TITLE
Add initial environment docs and core service scaffolding

### DIFF
--- a/docs/environment-core.md
+++ b/docs/environment-core.md
@@ -1,0 +1,51 @@
+# Environment & Core Service Setup
+
+This guide explains how to set up the initial Azure environment and the skeleton License Service. It follows the steps outlined in [Project Planning](planning.md) for **Environment & Core Service**.
+
+## Prerequisites
+
+- An [Azure](https://azure.microsoft.com/) subscription with permissions to create resources.
+- The [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) with [Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) support.
+- [.NET SDK 8.0](https://learn.microsoft.com/dotnet/core/install) for building the License Service.
+
+## Deploying the Environment
+
+The `infra/main.bicep` file provisions core resources:
+
+- **Storage Account** – required for Function App runtime storage.
+- **App Service Plan** – a consumption plan for the Function App.
+- **Function App** – hosts the License Service.
+- **API Management** – exposes API endpoints and manages subscription keys.
+
+### 1. Configure parameters
+
+Edit `infra/main.bicep` to set values like the environment name and publisher email. Parameters can also be supplied on deployment.
+
+### 2. Deploy with Azure CLI
+
+```bash
+az deployment sub create \
+  --location <region> \
+  --template-file infra/main.bicep \
+  --parameters environmentName=myenv publisherEmail=admin@example.com
+```
+
+The CLI compiles the Bicep file and creates the resources in your subscription. See [Deploy resources with Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/deploy-to-azure) for more deployment options.
+
+## Building the License Service
+
+The License Service is a minimal ASP.NET Core API located in `src/LicenseService`.
+
+### Restore and build
+
+```bash
+cd src/LicenseService
+ dotnet restore
+ dotnet build
+```
+
+The service exposes a simple health endpoint at `/api/health`. You can run it locally with `dotnet run` or deploy it to the Function App created earlier. Refer to [Deploy a .NET Function App](https://learn.microsoft.com/azure/azure-functions/functions-develop-vs-code?tabs=csharp) for detailed deployment steps.
+
+## Next Steps
+
+Once the environment is deployed and the service builds successfully, continue with Stripe integration and additional license logic as described in the planning document.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ Subscription Framework provides a fully featured licensing service built on Azur
 
 Detailed planning information, including the overall scope, development phases, and a proposed timeline, is available in [Project Planning](planning.md).
 
+For instructions on provisioning the initial Azure resources and building the core License Service see [Environment & Core Service Setup](environment-core.md).
+
 ---
 
 ## Getting Started

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,54 @@
+param environmentName string = 'licensing'
+param location string = resourceGroup().location
+param publisherEmail string
+
+resource storage 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: toLower('${environmentName}sa')
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+resource plan 'Microsoft.Web/serverfarms@2022-09-01' = {
+  name: '${environmentName}-plan'
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
+  name: '${environmentName}-func'
+  location: location
+  kind: 'functionapp'
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: storage.properties.primaryEndpoints.blob
+        }
+      ]
+    }
+  }
+}
+
+resource apim 'Microsoft.ApiManagement/service@2022-08-01' = {
+  name: '${environmentName}-apim'
+  location: location
+  sku: {
+    name: 'Consumption'
+    capacity: 0
+  }
+  properties: {
+    publisherEmail: publisherEmail
+    publisherName: 'Cadtastic Solutions'
+  }
+}
+
+output functionUrl string = 'https://' + functionApp.properties.defaultHostName

--- a/src/LicenseService/Controllers/HealthController.cs
+++ b/src/LicenseService/Controllers/HealthController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace LicenseService.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class HealthController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Get() => Ok(new { status = "Healthy" });
+    }
+}

--- a/src/LicenseService/LicenseService.csproj
+++ b/src/LicenseService/LicenseService.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/LicenseService/Program.cs
+++ b/src/LicenseService/Program.cs
@@ -1,0 +1,10 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapGet("/", () => "License Service");
+app.MapControllers();
+
+app.Run();

--- a/src/LicenseService/appsettings.json
+++ b/src/LicenseService/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- document Environment & Core Service setup
- link environment guide from index
- add Bicep template for Azure resources
- scaffold minimal License Service ASP.NET Core API

## Testing
- `bicep build infra/main.bicep` *(fails: command not found)*
- `dotnet build src/LicenseService/LicenseService.csproj` *(fails: command not found)*