### PR TITLE
Add admin dashboard docs and starter code

### DIFF
--- a/docs/admin-dashboard/how-to-azure-setup.md
+++ b/docs/admin-dashboard/how-to-azure-setup.md
@@ -1,0 +1,26 @@
+# Azure Setup How-To
+
+This guide describes how to provision Azure resources for the Admin Dashboard using the provided Bicep template.
+
+## Prerequisites
+
+- Azure CLI with Bicep installed
+- An Azure subscription with permission to create resources
+
+## Steps
+
+1. Clone the repository and navigate to the `infra` folder:
+   ```bash
+   git clone https://github.com/Cadtastic-Solutions/Subscription-Framework.git
+   cd Subscription-Framework/infra
+   ```
+2. Deploy the template (replace `myResourceGroup` and `myLocation` as needed):
+   ```bash
+   az group create -n myResourceGroup -l myLocation
+   az deployment group create -g myResourceGroup -f adminDashboard.bicep \
+     -p webAppName=my-admin-dashboard
+   ```
+
+The template creates an App Service plan, a Web App, and Application Insights.
+
+For more details see [Azure Bicep documentation](https://learn.microsoft.com/azure/azure-resource-manager/bicep/).

--- a/docs/admin-dashboard/index.md
+++ b/docs/admin-dashboard/index.md
@@ -1,0 +1,8 @@
+# Admin Dashboard Overview
+
+The Admin Dashboard is a secure web portal for internal administrators to manage customers, plans and licenses.
+
+This section provides documentation and setup instructions for hosting the dashboard in Azure.
+
+- [User Manual](user-manual.md)
+- [Azure Setup How-To](how-to-azure-setup.md)

--- a/docs/admin-dashboard/user-manual.md
+++ b/docs/admin-dashboard/user-manual.md
@@ -1,0 +1,27 @@
+# Admin Dashboard User Manual
+
+This guide explains how administrators can sign in and manage customers, plans and licenses.
+
+## Sign In
+
+1. Navigate to the dashboard URL provided by your deployment.
+2. Sign in using your corporate Azure AD credentials.
+
+## Viewing Customers
+
+- Use the **Customers** menu to search and view customer accounts.
+- Selecting a customer displays their active plans and license keys.
+
+## Managing Plans
+
+- Navigate to **Plans** to create or update subscription plans.
+- Changes are synchronized with Azure API Management and Stripe.
+
+## License Keys
+
+- The **Licenses** page lists all issued keys.
+- Administrators can revoke or regenerate a key if necessary.
+
+## Auditing
+
+All actions are logged for security. Use the **Audit Log** page to review recent changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the **Subscription Framework** project! This repository is part of Ca
 
 - [About the Project](#about-the-project)
 - [Project Planning](#project-planning)
+- [Admin Dashboard Documentation](admin-dashboard/)
 - [Getting Started](#getting-started)
 - [Usage](#usage)
 - [Contributing](#contributing)

--- a/infra/adminDashboard.bicep
+++ b/infra/adminDashboard.bicep
@@ -1,0 +1,33 @@
+param webAppName string
+param location string = resourceGroup().location
+
+resource plan 'Microsoft.Web/serverfarms@2022-09-01' = {
+  name: '${webAppName}-plan'
+  location: location
+  sku: {
+    name: 'B1'
+    tier: 'Basic'
+  }
+}
+
+resource app 'Microsoft.Web/sites@2022-09-01' = {
+  name: webAppName
+  location: location
+  properties: {
+    serverFarmId: plan.id
+    siteConfig: {
+      linuxFxVersion: 'DOTNETCORE|6.0'
+    }
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: '${webAppName}-insights'
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+  }
+}
+
+output webAppUrl string = 'https://${app.properties.defaultHostName}'

--- a/src/AdminDashboard/AdminDashboard.csproj
+++ b/src/AdminDashboard/AdminDashboard.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/AdminDashboard/Pages/Index.cshtml
+++ b/src/AdminDashboard/Pages/Index.cshtml
@@ -1,0 +1,4 @@
+@page
+@model IndexModel
+<h1>Admin Dashboard</h1>
+<p>Welcome to the admin dashboard.</p>

--- a/src/AdminDashboard/Pages/Index.cshtml.cs
+++ b/src/AdminDashboard/Pages/Index.cshtml.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+public class IndexModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/src/AdminDashboard/Program.cs
+++ b/src/AdminDashboard/Program.cs
@@ -1,0 +1,19 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+app.UseAuthorization();
+app.MapRazorPages();
+
+app.Run();

--- a/src/AdminDashboard/README.md
+++ b/src/AdminDashboard/README.md
@@ -1,0 +1,14 @@
+# Admin Dashboard Sample
+
+This ASP.NET Core 6 Razor Pages application serves as the starting point for the internal admin dashboard.
+
+## Running Locally
+
+1. Ensure the .NET 6 SDK is installed.
+2. Navigate to this folder and run:
+   ```bash
+   dotnet run
+   ```
+3. The app listens on `https://localhost:5001` by default.
+
+Refer to the [User Manual](../../docs/admin-dashboard/user-manual.md) for feature details.


### PR DESCRIPTION
## Summary
- document Admin Dashboard overview, manual and Azure setup
- link new docs in docs index
- add Bicep template for deploying an App Service instance
- scaffold a minimal ASP.NET Core Razor Pages app

## Testing
- `dotnet build` *(fails: command not found)*
- `bicep build infra/adminDashboard.bicep` *(fails: command not found)*