### PR TITLE
Add Stripe integration docs and Azure templates

### DIFF
--- a/docs/howto-stripe.md
+++ b/docs/howto-stripe.md
@@ -1,0 +1,45 @@
+# How To: Integrate Stripe and Automate Subscriptions
+
+This guide explains how to configure Stripe and Azure resources to automate license provisioning for the Subscription Framework. It complements the planning document's Phase 2 tasks.
+
+## Prerequisites
+
+- A [Stripe](https://stripe.com/docs) account with API keys
+- An Azure subscription
+- Azure CLI with Bicep installed
+
+## Steps
+
+1. **Create Stripe Products**
+   - In the Stripe Dashboard, create Products and recurring Prices that match your license plans.
+   - Note the price IDs; they will be used in checkout links or API calls.
+
+2. **Deploy Webhook Handler**
+   - Use the Bicep template in `templates/stripe-subscription.bicep` to deploy a Function App configured for webhook processing.
+   - Example deployment command:
+     ```bash
+     az deployment group create \
+       --resource-group <rg> \
+       --template-file templates/stripe-subscription.bicep \
+       --parameters storageAccountName=<name> \
+                    functionAppName=<app-name> \
+                    appServicePlanName=<plan-name> \
+                    apimServiceName=<apim-name>
+     ```
+   - Set the `STRIPE_SECRET` and `STRIPE_WEBHOOK_SECRET` application settings for the Function App.
+
+3. **Configure Stripe Webhook**
+   - In Stripe, add an endpoint pointing to `https://<functionAppUrl>/api/stripe/webhook`.
+   - Subscribe to events such as `invoice.paid`, `customer.subscription.created`, and `invoice.payment_failed`.
+
+4. **Automate APIM Subscription Creation**
+   - The webhook handler should call the Azure API Management REST API to create or update subscriptions when payments succeed.
+   - Refer to [APIM REST documentation](https://learn.microsoft.com/azure/api-management/api-management-howto-develop-with-rest) for required headers and authentication.
+
+5. **Testing**
+   - Use Stripe's CLI or dashboard to send test webhook events to the Function App.
+   - Verify that licenses are created or updated in your database and APIM.
+
+## Next Steps
+
+After the webhook flow is verified, integrate this with your License Service for full lifecycle management.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ Welcome to the **Subscription Framework** project! This repository is part of Ca
 
 - [About the Project](#about-the-project)
 - [Project Planning](#project-planning)
+- [Stripe Integration Guide](howto-stripe.md)
+- [Subscription Management Manual](user-manual-subscriptions.md)
 - [Getting Started](#getting-started)
 - [Usage](#usage)
 - [Contributing](#contributing)

--- a/docs/user-manual-subscriptions.md
+++ b/docs/user-manual-subscriptions.md
@@ -1,0 +1,35 @@
+# User Manual: Managing Subscriptions
+
+This manual describes how administrators can manage customer subscriptions when using the Subscription Framework. It focuses on the Stripe integration developed in Phase 2 of the project plan.
+
+## Overview
+
+Customers purchase plans through Stripe. Webhook events trigger automated license creation in Azure API Management (APIM) and update records in the License Service database.
+
+## Admin Tasks
+
+### Viewing Subscriptions
+1. Sign in to the Stripe Dashboard and open the **Customers** section to see active subscriptions.
+2. The License Service dashboard (to be developed) will also display subscription status, payment history, and associated APIM keys.
+
+### Pausing or Canceling
+- To pause billing, use Stripe's **Pause collection** feature. The webhook handler marks the license as suspended, preventing API access.
+- To cancel, cancel the subscription in Stripe. The webhook handler deactivates the license and, if desired, deletes the APIM subscription.
+
+### Payment Failures
+- Stripe automatically retries failed payments according to your settings.
+- After the retry schedule, the webhook handler marks the license inactive. You can manually reactivate once payment issues are resolved.
+
+### Issuing Trials
+- Create a price with a trial period or a $0 plan in Stripe.
+- When the trial starts, a license is issued just like a paid plan but flagged as trial in the database.
+
+## Customer Experience
+
+1. Customer completes checkout and receives a confirmation email containing the API key.
+2. The client application uses this key along with the `X-App-Id` header for license validation via APIM.
+3. If payment lapses or the subscription is canceled, subsequent validations will fail after any configured grace period.
+
+## Support
+
+For issues with subscription status or billing, administrators should consult both Stripe logs and the License Service logs. Common problems include webhook secret mismatch and API failures when creating APIM subscriptions.

--- a/src/StripeWebhook/function.json
+++ b/src/StripeWebhook/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "stripe/webhook"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/src/StripeWebhook/index.js
+++ b/src/StripeWebhook/index.js
@@ -1,0 +1,33 @@
+const stripe = require('stripe')(process.env.STRIPE_SECRET);
+
+module.exports = async function (context, req) {
+  const sig = req.headers['stripe-signature'];
+  const body = req.rawBody;
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    context.log('Webhook signature verification failed.', err.message);
+    context.res = { status: 400 };
+    return;
+  }
+
+  context.log(`Received event type ${event.type}`);
+
+  switch (event.type) {
+    case 'invoice.paid':
+      // Handle successful payment
+      break;
+    case 'customer.subscription.created':
+      // Provision license on new subscription
+      break;
+    case 'invoice.payment_failed':
+      // Flag payment failure
+      break;
+    default:
+      context.log(`Unhandled event type ${event.type}`);
+  }
+
+  context.res = { status: 200 };
+};

--- a/src/StripeWebhook/package.json
+++ b/src/StripeWebhook/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "stripe-webhook-handler",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "stripe": "^14.0.0"
+  }
+}

--- a/templates/stripe-subscription.bicep
+++ b/templates/stripe-subscription.bicep
@@ -1,0 +1,69 @@
+// Bicep template for Subscription Framework
+// Deploys resources needed for Stripe webhook handling and APIM integration
+
+param location string = resourceGroup().location
+param storageAccountName string
+param functionAppName string
+param appServicePlanName string
+param apimServiceName string
+
+resource storage 'Microsoft.Storage/storageAccounts@2022-05-01' = {
+  name: storageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+}
+
+resource plan 'Microsoft.Web/serverfarms@2022-09-01' = {
+  name: appServicePlanName
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp'
+  properties: {
+    serverFarmId: plan.id
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: storage.properties.primaryEndpoints.blob
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'WEBSITE_RUN_FROM_PACKAGE'
+          value: '1'
+        }
+      ]
+    }
+  }
+}
+
+resource apim 'Microsoft.ApiManagement/service@2022-08-01' existing = {
+  name: apimServiceName
+}
+
+resource webhook 'Microsoft.ApiManagement/service/apis@2022-08-01' = {
+  parent: apim
+  name: 'stripe-webhook'
+  properties: {
+    displayName: 'Stripe Webhook API'
+    path: 'stripe/webhook'
+    protocols: [ 'https' ]
+    subscriptionRequired: false
+    isCurrent: true
+  }
+}
+
+output functionAppUrl string = functionApp.properties.defaultHostName


### PR DESCRIPTION
## Summary
- document how to integrate Stripe and automate subscriptions
- add subscription management user manual
- link docs from main index
- add sample Node webhook handler
- provide bicep template for webhook infrastructure

## Testing
- `node -c src/StripeWebhook/index.js`
- `npm install` *(fails: EHOSTUNREACH)*
- `bicep build templates/stripe-subscription.bicep` *(fails: command not found)*
